### PR TITLE
make regex pattern non-greedy

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -20,7 +20,7 @@ class syntax_plugin_hidepages extends DokuWiki_Syntax_Plugin {
     function getSort(){ return 990; }
  
     function connectTo($mode) {
-        $this->Lexer->addSpecialPattern('~~HIDEPAGE.*~~', $mode, 'plugin_hidepages');
+        $this->Lexer->addSpecialPattern('~~HIDEPAGE.*?~~', $mode, 'plugin_hidepages');
     }
  
     function handle($match, $state, $pos, &$handler){


### PR DESCRIPTION
The connect `.*~~` regex pattern matches other markup such `~~NOTOC~~`.
