### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -17,7 +17,7 @@ require_once DOKU_PLUGIN.'action.php';
 
 class action_plugin_hidepages extends DokuWiki_Action_Plugin {
 
-    public function register(Doku_Event_Handler &$controller) {
+    public function register(Doku_Event_Handler $controller) {
         $controller->register_hook('PAGEUTILS_ID_HIDEPAGE', 'BEFORE', $this, 'handle_hidepages');
     }
 

--- a/syntax.php
+++ b/syntax.php
@@ -23,7 +23,7 @@ class syntax_plugin_hidepages extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern('~~HIDEPAGE.*?~~', $mode, 'plugin_hidepages');
     }
  
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         $data = array();
         $match = hsc(trim($match));
 
@@ -51,7 +51,7 @@ class syntax_plugin_hidepages extends DokuWiki_Syntax_Plugin {
         return $data;
     }
 
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if($mode == "metadata") {
             // set flag in metadata to hide page in action component
             if(!is_array($data)) {


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
